### PR TITLE
[Sync] Update project files from source repository (d45d090)

### DIFF
--- a/.github/actions/setup-benchstat/action.yml
+++ b/.github/actions/setup-benchstat/action.yml
@@ -15,8 +15,20 @@
 #    - uses: ./.github/actions/setup-benchstat
 #      with:
 #        benchstat-version: ${{ env.MAGE_X_BENCHSTAT_VERSION }}
+#        benchstat-version-latest: ${{ env.MAGE_X_BENCHSTAT_VERSION_LATEST }}
+#        benchstat-latest-min-go: ${{ env.MAGE_X_BENCHSTAT_VERSION_LATEST_MIN_GO }}
 #        runner-os: ${{ runner.os }}
 #        go-version: ${{ matrix.go-version }}
+#
+#  Version selection (golang.org/x/perf raises its go.mod 'go' directive over time, so the
+#  newest build will not `go install` on an older toolchain). The choice keys off the
+#  runner's Go version so this works unchanged across the many projects that sync these
+#  env files, each of which may run a different Go version:
+#    - Go < 1.25                     -> skipped (benchstat requires Go 1.25+)
+#    - Go 1.25.x .. below min-go      -> benchstat-version         (newest build for Go 1.25)
+#    - Go >= benchstat-latest-min-go  -> benchstat-version-latest  (newest build overall)
+#  benchstat-latest-min-go tracks the Go version the latest build needs and is kept current
+#  by `magex updateToolVersions`, so no threshold is hard-coded here.
 #
 #  Maintainer: @mrz1836
 #
@@ -27,13 +39,21 @@ description: "Install and cache benchstat binary for benchmark comparison"
 
 inputs:
   benchstat-version:
-    description: "Benchstat version to install (e.g., v0.6.0)"
+    description: "Benchstat build for runners below latest-min-go (newest build that still supports Go 1.25, e.g., v0.0.0-...)"
     required: true
+  benchstat-version-latest:
+    description: "Newest benchstat build overall. Used on runners whose Go >= latest-min-go. Defaults to benchstat-version when unset."
+    required: false
+    default: ""
+  benchstat-latest-min-go:
+    description: "Minimum Go version required by benchstat-version-latest (e.g., 1.26). Runners at or above this use the latest build; older ones use benchstat-version."
+    required: false
+    default: "1.26"
   runner-os:
     description: "Runner OS for cache key (e.g., ubuntu-latest, mac-latest)"
     required: true
   go-version:
-    description: "Go version being used (e.g., 1.25.x, 1.24). Benchstat requires Go 1.25+"
+    description: "Go version being used (e.g., 1.25.x, 1.26.x). Benchstat requires Go 1.25+"
     required: true
 
 outputs:
@@ -46,39 +66,91 @@ outputs:
   skipped:
     description: "Whether benchstat installation was skipped due to Go version < 1.25"
     value: ${{ steps.version-check.outputs.skip }}
+  resolved-version:
+    description: "The benchstat version selected for the runner's Go version. Empty when skipped."
+    value: ${{ steps.version-check.outputs.resolved-version }}
 
 runs:
   using: "composite"
   steps:
     # --------------------------------------------------------------------
-    # Check Go version compatibility (benchstat requires Go 1.25+)
+    # Check Go version compatibility and select the benchstat build
+    #
+    # benchstat (golang.org/x/perf) requires Go 1.25+ and raises its go.mod
+    # 'go' directive over time, so the newest build will not `go install` on
+    # an older toolchain. Pick the build that matches the runner's Go version:
+    #   Go < 1.25                     -> skip
+    #   Go >= benchstat-latest-min-go -> benchstat-version-latest  (newest overall)
+    #   otherwise (Go 1.25.x)         -> benchstat-version         (newest for Go 1.25)
+    # The min-go threshold is passed in (not hard-coded) so this stays correct across
+    # projects and future benchstat 'go' directive bumps.
     # --------------------------------------------------------------------
     - name: 🔍 Check Go version compatibility
       id: version-check
       shell: bash
+      env:
+        # Route versions through env: so they can never break out of the shell
+        # via ${{ }} interpolation (they are config, but keep the safe pattern).
+        BENCHSTAT_VERSION: ${{ inputs.benchstat-version }}
+        # Fall back to the Go 1.25 build when no dedicated latest build is provided.
+        BENCHSTAT_VERSION_LATEST: ${{ inputs.benchstat-version-latest || inputs.benchstat-version }}
+        # Minimum Go version the latest build needs; defaults to 1.26 when unset.
+        BENCHSTAT_LATEST_MIN_GO: ${{ inputs.benchstat-latest-min-go || '1.26' }}
+        # go-version is matrix/caller-controlled, so route it through env: too (not
+        # directly interpolated into the script) to preserve the shell-safety invariant.
+        GO_VERSION: ${{ inputs.go-version }}
       run: |
-        GO_VERSION="${{ inputs.go-version }}"
         # Extract major and minor version:
         #   "1.24.x"  -> MAJOR=1, MINOR=24
         #   "1.22"    -> MAJOR=1, MINOR=22
         #   "1.23.5"  -> MAJOR=1, MINOR=23
         #   "2.0.0"   -> MAJOR=2, MINOR=0
-        MAJOR=$(echo "$GO_VERSION" | sed -E 's/^([0-9]+)\..*/\1/')
-        MINOR=$(echo "$GO_VERSION" | sed -E 's/^[0-9]+\.([0-9]+).*/\1/')
+        # Anchored match so malformed inputs (e.g. "1.25junk", "127", "1.2z") are rejected
+        # by the validation below instead of being silently coerced — the old sed-based
+        # extraction accepted "1.25junk" as 1.25. Mirrors the BENCHSTAT_LATEST_MIN_GO check.
+        if [[ "$GO_VERSION" =~ ^([0-9]+)\.([0-9]+)(\.(x|[0-9]+))?$ ]]; then
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+        else
+          MAJOR=""
+          MINOR=""
+        fi
 
-        if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || ! [[ "$MAJOR" =~ ^[0-9]+$ ]] || ! [[ "$MINOR" =~ ^[0-9]+$ ]]; then
+        # Parse and validate the latest-build minimum Go threshold. Empty input already
+        # defaults to 1.26 above, so a non-empty value that fails to parse is a real config
+        # error (typo). Fail fast with a clear message rather than silently falling back to a
+        # possibly-stale hard-coded 1.26, which could select an incompatible build once the
+        # latest benchstat requires Go 1.27+. Anchored match also rejects inputs the old
+        # sed-based check missed (e.g. "127", "1.2z"). Mirrors the GO_VERSION check below.
+        if [[ "$BENCHSTAT_LATEST_MIN_GO" =~ ^([0-9]+)\.([0-9]+)(\.(x|[0-9]+))?$ ]]; then
+          MIN_MAJOR="${BASH_REMATCH[1]}"
+          MIN_MINOR="${BASH_REMATCH[2]}"
+        else
+          echo "❌ Could not parse benchstat latest minimum Go version '$BENCHSTAT_LATEST_MIN_GO'. Please provide a valid Go version (e.g., '1.26', '1.27.x')." >&2
+          exit 1
+        fi
+
+        # A valid Go version has MAJOR >= 1 (Go started at 1.0; there is no 0.x). Reject anything
+        # below that as malformed input rather than letting it fall through the floor check below
+        # and silently proceed with a benchstat install. The MAJOR/MINOR regex guards run first
+        # (|| short-circuits), so "$MAJOR" is a validated non-negative integer before "-lt 1".
+        if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || ! [[ "$MAJOR" =~ ^[0-9]+$ ]] || ! [[ "$MINOR" =~ ^[0-9]+$ ]] || [ "$MAJOR" -lt 1 ]; then
           echo "❌ Could not parse Go version '$GO_VERSION'. Please provide a valid Go version (e.g., '1.25', '1.26.x')." >&2
           exit 1
-        elif [ "$MAJOR" -gt 1 ]; then
-          # Any Go major version > 1 is considered compatible with the 1.25+ requirement
-          echo "✅ Go $GO_VERSION >= 1.25: proceeding with benchstat installation"
-          echo "skip=false" >> $GITHUB_OUTPUT
         elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -lt 25 ]; then
           echo "⚠️ Go $GO_VERSION < 1.25: skipping benchstat installation (requires Go 1.25+)"
-          echo "skip=true" >> $GITHUB_OUTPUT
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          echo "resolved-version=" >> "$GITHUB_OUTPUT"
+        elif [ "$MAJOR" -gt "$MIN_MAJOR" ] || { [ "$MAJOR" -eq "$MIN_MAJOR" ] && [ "$MINOR" -ge "$MIN_MINOR" ]; }; then
+          # Runner Go is new enough for the latest build.
+          echo "✅ Go $GO_VERSION >= $BENCHSTAT_LATEST_MIN_GO: using latest benchstat ($BENCHSTAT_VERSION_LATEST)"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "resolved-version=$BENCHSTAT_VERSION_LATEST" >> "$GITHUB_OUTPUT"
         else
-          echo "✅ Go $GO_VERSION >= 1.25: proceeding with benchstat installation"
-          echo "skip=false" >> $GITHUB_OUTPUT
+          # Go 1.25.x (below the latest build's requirement): use the Go 1.25 build.
+          echo "✅ Go $GO_VERSION is below $BENCHSTAT_LATEST_MIN_GO: using Go 1.25-compatible benchstat ($BENCHSTAT_VERSION)"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "resolved-version=$BENCHSTAT_VERSION" >> "$GITHUB_OUTPUT"
         fi
 
     # --------------------------------------------------------------------
@@ -90,7 +162,7 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/benchstat-bin
-        key: ${{ inputs.runner-os }}-benchstat-${{ inputs.benchstat-version }}
+        key: ${{ inputs.runner-os }}-benchstat-${{ steps.version-check.outputs.resolved-version }}
 
     # --------------------------------------------------------------------
     # Install cached binary to PATH when cache hits
@@ -118,7 +190,8 @@ runs:
       env:
         # Route the version through env: so it can never break out of the go install
         # command via ${{ }} interpolation (completes the safe pattern; version is config).
-        BENCHSTAT_VERSION: ${{ inputs.benchstat-version }}
+        # resolved-version is the Go-version-appropriate build chosen by version-check.
+        BENCHSTAT_VERSION: ${{ steps.version-check.outputs.resolved-version }}
       run: |
         echo "⬇️ Cache miss – installing benchstat via go install..."
         echo "📋 Installing benchstat version: $BENCHSTAT_VERSION"

--- a/.github/actions/validate-test-results/action.yml
+++ b/.github/actions/validate-test-results/action.yml
@@ -51,14 +51,9 @@ runs:
         set -uo pipefail
         echo "🔍 Validating test results from CI mode output..."
         source .github/scripts/parse-test-label.sh
-
-        # Guard against bash arithmetic-eval injection: artifact-derived counts flow into
-        # $(( )) and [[ -gt ]]. Coerce each to a bare non-negative integer so a crafted
-        # JSONL value like "a[$(cmd)]" becomes 0 instead of being evaluated as code.
-        to_int() {
-          local v="${1//[[:space:]]/}"
-          if [[ "$v" =~ ^[0-9]+$ ]]; then printf '%s' "$v"; else printf '0'; fi
-        }
+        # to_int (arithmetic-eval injection guard) and effective_failures (process-level
+        # failures count as 1) are shared so this step and the summary step can't drift.
+        source .github/scripts/test-result-helpers.sh
 
         VALIDATION_FAILED=false
         TOTAL_FAILURES=0
@@ -134,9 +129,14 @@ runs:
               # specific package or test, reports status "error"/"failed" and/or a
               # non-zero exit_code while failed can still be 0. Any one of these
               # signals disagreeing with "everything passed" must fail validation.
-              if [[ "$STATUS" == "failed" ]] || [[ "$STATUS" == "error" ]] || [[ "$FAILED" -gt 0 ]] || [[ "$EXIT_CODE" -gt 0 ]]; then
+              # effective_failures() encodes exactly that predicate (>0 == failed)
+              # and counts a detail-less process failure as 1, so TOTAL_FAILURES —
+              # and the final "N failure(s) detected" message — never undercounts
+              # to 0 for a job that failed.
+              FAILURES=$(effective_failures "$STATUS" "$FAILED" "$EXIT_CODE")
+              if [[ "$FAILURES" -gt 0 ]]; then
                 VALIDATION_FAILED=true
-                TOTAL_FAILURES=$((TOTAL_FAILURES + FAILED))
+                TOTAL_FAILURES=$((TOTAL_FAILURES + FAILURES))
 
                 if [[ "$FAILED" -eq 0 ]]; then
                   echo ""
@@ -229,14 +229,11 @@ runs:
       run: |
         set -uo pipefail
         source .github/scripts/parse-test-label.sh
+        # Shared to_int (arithmetic-eval injection guard) + effective_failures (process-level
+        # failures count as 1), kept in one place so this summary step and the validation
+        # step above can't drift.
+        source .github/scripts/test-result-helpers.sh
 
-        # Coerce artifact-derived counts to integers (arithmetic-eval injection guard) and
-        # strip backticks from artifact-derived text before it is written into the job
-        # summary (prevents markdown code-span / fenced-block breakout & content spoofing).
-        to_int() {
-          local v="${1//[[:space:]]/}"
-          if [[ "$v" =~ ^[0-9]+$ ]]; then printf '%s' "$v"; else printf '0'; fi
-        }
         # Strip backticks AND control chars (except tab/newline) from artifact-derived text:
         # prevents code-span/fenced-block breakout and control-character (ANSI/NUL) spoofing.
         strip_bt() { printf '%s' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\140\177'; }
@@ -254,7 +251,6 @@ runs:
           s=${s//>/&gt;}
           printf '%s' "$s"
         }
-
         echo "## 🔍 Test Validation Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
@@ -268,21 +264,33 @@ runs:
         TOTAL_SKIPPED=0
         TOTAL_UNIQUE=0
         TOTAL_TESTS=0
+        # Real "type":"failure" entries across all files. Tracked separately from
+        # TOTAL_FAILED because a process-level failure counts toward TOTAL_FAILED
+        # but produces no expandable failure entry — this gates the details section.
+        TOTAL_FAILURE_ENTRIES=0
 
         while IFS= read -r -d '' jsonl_file; do
           SUMMARY=$(grep '"type":"summary"' "$jsonl_file" 2>/dev/null | head -1 || echo "")
           if [[ -n "$SUMMARY" ]]; then
+            STATUS=$(echo "$SUMMARY" | jq -r '.summary.status // "unknown"')
             PASSED=$(to_int "$(echo "$SUMMARY" | jq -r '.summary.passed // 0')")
             FAILED=$(to_int "$(echo "$SUMMARY" | jq -r '.summary.failed // 0')")
             SKIPPED=$(to_int "$(echo "$SUMMARY" | jq -r '.summary.skipped // 0')")
             UNIQUE=$(to_int "$(echo "$SUMMARY" | jq -r '.summary.unique_total // 0')")
             TOTAL=$(to_int "$(echo "$SUMMARY" | jq -r '.summary.total // 0')")
+            EXIT_CODE=$(to_int "$(echo "$SUMMARY" | jq -r '.summary.exit_code // 0')")
             TOTAL_PASSED=$((TOTAL_PASSED + PASSED))
-            TOTAL_FAILED=$((TOTAL_FAILED + FAILED))
+            # Count process-level failures (build/setup errors with failed=0), not
+            # just individual test failures, so this total matches the validation
+            # step and never shows 0 for a job that failed.
+            TOTAL_FAILED=$((TOTAL_FAILED + $(effective_failures "$STATUS" "$FAILED" "$EXIT_CODE")))
             TOTAL_SKIPPED=$((TOTAL_SKIPPED + SKIPPED))
             TOTAL_UNIQUE=$((TOTAL_UNIQUE + UNIQUE))
             TOTAL_TESTS=$((TOTAL_TESTS + TOTAL))
           fi
+          # grep -c exits 1 on zero matches; ignore its status (it still prints 0).
+          FAILURE_ENTRIES=$(to_int "$(grep -c '"type":"failure"' "$jsonl_file" 2>/dev/null || true)")
+          TOTAL_FAILURE_ENTRIES=$((TOTAL_FAILURE_ENTRIES + FAILURE_ENTRIES))
         done < <(find ci-results/ -name "*.jsonl" -print0 2>/dev/null)
 
         echo "- **Unique Tests**: $TOTAL_UNIQUE" >> $GITHUB_STEP_SUMMARY
@@ -336,8 +344,10 @@ runs:
           done < <(find ci-results/ -name "*.jsonl" -print0 2>/dev/null)
         fi
 
-        # Add detailed failure section if there are failures
-        if [[ $TOTAL_FAILED -gt 0 ]]; then
+        # Add detailed failure section only when there are real failure entries to
+        # expand. Gated on TOTAL_FAILURE_ENTRIES (not TOTAL_FAILED) so a detail-less
+        # process/build failure doesn't render an empty "Failure Details" section.
+        if [[ $TOTAL_FAILURE_ENTRIES -gt 0 ]]; then
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 🚨 Failure Details" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/env/00-core.env
+++ b/.github/env/00-core.env
@@ -29,7 +29,7 @@ GO_PRIMARY_VERSION=1.24.x
 GO_SECONDARY_VERSION=1.24.x
 
 # Govulncheck-specific Go version for vulnerability scanning
-GOVULNCHECK_GO_VERSION=1.26.6
+GOVULNCHECK_GO_VERSION=1.27.0
 
 # ================================================================================================
 # 📦 GO MODULE CONFIGURATION

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.26.3
+MAGE_X_VERSION=v1.26.4
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false
@@ -71,7 +71,7 @@ MAGE_X_FORMAT_EXCLUDE_PATHS=vendor,node_modules,.git,.idea
 
 MAGE_X_GITLEAKS_VERSION=8.30.1
 MAGE_X_GOFUMPT_VERSION=v0.11.0
-MAGE_X_GOLANGCI_LINT_VERSION=v2.12.2
+MAGE_X_GOLANGCI_LINT_VERSION=v2.13.1
 MAGE_X_GORELEASER_VERSION=v2.17.1
 MAGE_X_GOVULNCHECK_VERSION=v1.7.0
 MAGE_X_GO_SECONDARY_VERSION=1.24.x
@@ -81,10 +81,31 @@ MAGE_X_NANCY_VERSION=v2.1.0
 # OSV-Scanner version for MAGE-X parity (authoritative pin is OSV_SCANNER_VERSION in
 # 10-security.env, which the CI workflow uses to `go install` the scanner).
 MAGE_X_OSV_SCANNER_VERSION=v2.5.1
-MAGE_X_STATICCHECK_VERSION=2026.1
+MAGE_X_STATICCHECK_VERSION=2026.2.1
 MAGE_X_SWAG_VERSION=v1.16.6
 MAGE_X_YAMLFMT_VERSION=v0.21.0
+# benchstat is versioned by two pins. golang.org/x/perf ships only pseudo-versions
+# (no semver tags) and periodically raises the 'go' directive in its go.mod, which makes
+# the newest build refuse to `go install` on older toolchains. An older 'go' directive
+# still installs on newer Go, but never the reverse, so each CI Go version must install a
+# build it actually supports:
+#   - MAGE_X_BENCHSTAT_VERSION:        newest build that still supports Go 1.25.x (this
+#                                      project's Go version, see 90-project.env). Read by
+#                                      mage-x (`magex bench`) and used by Go 1.25.x runners.
+#                                      Safe on Go >= 1.25.
+#   - MAGE_X_BENCHSTAT_VERSION_LATEST: newest build overall (currently requires Go 1.26+).
+#                                      Used by Go 1.26+ runners via setup-benchstat.
+# `magex updateToolVersions` keeps _LATEST at the Go proxy @latest, advances
+# MAGE_X_BENCHSTAT_VERSION only while @latest still supports Go 1.25, and keeps
+# _LATEST_MIN_GO in sync with the Go version the _LATEST build requires.
+#
+# These three values are the same for every project that syncs this file — only the
+# runner's Go version differs. setup-benchstat uses _LATEST_MIN_GO to pick, per runner:
+# runners on Go >= _LATEST_MIN_GO install _LATEST; Go 1.25.x runners install the held
+# MAGE_X_BENCHSTAT_VERSION; Go < 1.25 is skipped (benchstat's floor).
 MAGE_X_BENCHSTAT_VERSION=v0.0.0-20260813145340-fd4a688df892
+MAGE_X_BENCHSTAT_VERSION_LATEST=v0.0.0-20260819171926-ebcb4798430d
+MAGE_X_BENCHSTAT_VERSION_LATEST_MIN_GO=1.26
 MAGE_X_MAGE_VERSION=v1.17.2
 
 # ================================================================================================

--- a/.github/env/10-pre-commit.env
+++ b/.github/env/10-pre-commit.env
@@ -26,7 +26,7 @@
 # 🪝 PRE-COMMIT TOOL VERSION
 # ================================================================================================
 
-GO_PRE_COMMIT_VERSION=v1.10.0
+GO_PRE_COMMIT_VERSION=v1.10.1
 GO_PRE_COMMIT_USE_LOCAL=false
 
 # ================================================================================================
@@ -52,7 +52,7 @@ GO_PRE_COMMIT_ALL_FILES=true
 # 🛠️ TOOL VERSIONS
 # ================================================================================================
 
-GO_PRE_COMMIT_GOLANGCI_LINT_VERSION=v2.12.2
+GO_PRE_COMMIT_GOLANGCI_LINT_VERSION=v2.13.1
 GO_PRE_COMMIT_FUMPT_VERSION=v0.11.0
 GO_PRE_COMMIT_GOIMPORTS_VERSION=latest
 GO_PRE_COMMIT_GITLEAKS_VERSION=v8.30.1

--- a/.github/scripts/test-result-helpers.sh
+++ b/.github/scripts/test-result-helpers.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------------------------------
+# Test Result Helpers
+#
+# Shared helpers for validating and summarizing CI test-result JSONL. Sourced by both
+# steps of the validate-test-results composite action so the two stay in lock-step
+# (a single definition can't drift between the validation and summary passes).
+#
+# Provides:
+#   to_int "value"                      -> bare non-negative integer (else 0)
+#   effective_failures "status" "failed" "exit_code" -> failure count for one job
+# ------------------------------------------------------------------------------------
+
+# Coerce an artifact-derived value to a bare non-negative integer. Counts flow into
+# $(( )) and [[ -gt ]], so a crafted JSONL value like "a[$(cmd)]" must become 0 rather
+# than being evaluated as code (arithmetic-eval injection guard).
+to_int() {
+  local v="${1//[[:space:]]/}"
+  if [[ "$v" =~ ^[0-9]+$ ]]; then printf '%s' "$v"; else printf '0'; fi
+}
+
+# effective_failures: how many failures a single job summary represents.
+# Individual test failures are counted exactly; a job that failed only at the process
+# level (build/setup error -> status "error"/"failed" and/or a non-zero exit_code while
+# failed=0) still counts as 1, so an aggregate can never misreport "0 failure(s)" for a
+# job that actually failed. Echoes 0 for a fully-passing job, so its >0 result doubles
+# as the "did this job fail?" predicate. Inputs are re-coerced to integers so the helper
+# is safe against arithmetic-eval injection regardless of caller.
+effective_failures() {
+  local status="$1" failed exit_code
+  failed=$(to_int "$2")
+  exit_code=$(to_int "$3")
+  if [[ "$failed" -gt 0 ]]; then
+    printf '%s' "$failed"
+  elif [[ "$status" == "failed" || "$status" == "error" || "$exit_code" -gt 0 ]]; then
+    printf '1'
+  else
+    printf '0'
+  fi
+}

--- a/.github/workflows/fortress-test-matrix.yml
+++ b/.github/workflows/fortress-test-matrix.yml
@@ -1,11 +1,16 @@
 # ------------------------------------------------------------------------------------
 #  Test Matrix Execution (Reusable Workflow) (GoFortress)
 #
-#  Purpose: Execute Go tests across multiple operating systems and Go versions
+#  Purpose: Execute Go tests across the configured runners and Go versions
 #  in a matrix strategy with native CI mode for failure detection and reporting.
 #
 #  This workflow handles:
-#    - Multi-platform test execution (ubuntu, windows, macOS)
+#    - Linux test execution (any Linux runner; ubuntu-* by default). Windows and
+#      macOS are NOT supported: every step here is bash-only AND the test-go job
+#      declares a Linux service container, which only runs on Linux runners. The
+#      preflight rejects non-Linux (windows*/macos*) runners. Do not add
+#      windows/macos runners without restructuring the job (separate no-services
+#      job) and adding shells.
 #    - Multiple Go version testing (primary, secondary)
 #    - Race detection and code coverage
 #    - Native CI mode for GitHub annotations and JSONL output
@@ -107,10 +112,75 @@ permissions: {}
 
 jobs:
   # ----------------------------------------------------------------------------------
+  # Preflight: validate the caller-provided test matrix on a Linux runner
+  #
+  # This gates test-go (via `needs`) so an unsupported Windows runner fails fast with a
+  # clear message BEFORE test-go is scheduled. test-go declares a service container
+  # (redis, or a busybox placeholder when Redis is disabled), and GitHub initializes
+  # service containers during job setup — a phase that runs before every step and fails
+  # on Windows (service containers are Linux-only). An in-step guard inside test-go
+  # therefore cannot reliably run first; this preflight can, because a failed `needs`
+  # dependency prevents test-go (and all its matrix legs) from starting at all.
+  # ----------------------------------------------------------------------------------
+  validate-matrix:
+    name: 🧭 Validate test matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: 🛑 Reject unsupported non-Linux runners
+        shell: bash
+        env:
+          # Route the matrix JSON through env: so it can't break out of the shell
+          # via ${{ }} interpolation.
+          TEST_MATRIX: ${{ inputs.test-matrix }}
+        run: |
+          # Fail fast on invalid JSON so the real error isn't a confusing fromJSON
+          # failure later in test-go.
+          if ! jq empty <<< "$TEST_MATRIX" 2>/dev/null; then
+            echo "::error title=Invalid test matrix::The test-matrix input is not valid JSON."
+            exit 1
+          fi
+
+          # Valid JSON isn't enough: a matrix must be an object. Guard here so a
+          # non-object (array/string/number) fails with this clear annotation instead
+          # of a raw jq indexing error in the extraction below.
+          if [[ "$(jq -r 'type' <<< "$TEST_MATRIX")" != "object" ]]; then
+            echo "::error title=Invalid test matrix::The test-matrix input must be a JSON object with an \"os\" array and/or an \"include\" array of entries containing \"os\"."
+            exit 1
+          fi
+
+          # Collect every runner OS from both include-based and classic matrix shapes,
+          # then reject any non-Linux runner. This workflow is bash-only AND the
+          # test-go job unconditionally declares a service container (redis, or a
+          # busybox placeholder when disabled). Service containers require Docker and
+          # only run on Linux runners, so a macOS or Windows leg would fail at job
+          # setup ("Initialize containers") before any step runs.
+          UNSUPPORTED=$(jq -r '
+            [ (.include // [] | map(.os // empty)), (.os // []) ]
+            | flatten
+            | map(select(type == "string" and (ascii_downcase | (startswith("windows") or startswith("macos")))))
+            | unique | join(", ")
+          ' <<< "$TEST_MATRIX")
+
+          if [[ -n "$UNSUPPORTED" ]]; then
+            # Percent-encode before embedding untrusted matrix values in output, so a
+            # value containing %, CR or LF can't inject its own ::workflow-commands
+            # (workflow-command injection). % must be encoded first to avoid double-decode.
+            esc() { local s=$1; s=${s//'%'/%25}; s=${s//$'\r'/%0D}; s=${s//$'\n'/%0A}; printf '%s' "$s"; }
+            SAFE_UNSUPPORTED=$(esc "$UNSUPPORTED")
+            echo "::error title=Unsupported runner::Test matrix contains non-Linux runner(s): ${SAFE_UNSUPPORTED}. This workflow is bash-only and uses a Linux service container, so only Linux runners are supported (ubuntu-* by default). Set PRIMARY_RUNNER/SECONDARY_RUNNER to a Linux runner."
+            echo "❌ Non-Linux runners in matrix: ${SAFE_UNSUPPORTED}"
+            exit 1
+          fi
+          echo "✅ Test matrix contains only supported Linux runners."
+
+  # ----------------------------------------------------------------------------------
   # Testing Matrix for Go (Parallel)
   # ----------------------------------------------------------------------------------
   test-go:
     name: 🧪 Test (${{ matrix.name }})
+    needs: validate-matrix # Gate on preflight so non-Linux entries fail before service setup
     timeout-minutes: 30 # Prevent hung tests
     permissions:
       contents: read # Read repository content for testing
@@ -188,6 +258,8 @@ jobs:
         uses: ./.github/actions/setup-benchstat
         with:
           benchstat-version: ${{ env.MAGE_X_BENCHSTAT_VERSION }}
+          benchstat-version-latest: ${{ env.MAGE_X_BENCHSTAT_VERSION_LATEST }}
+          benchstat-latest-min-go: ${{ env.MAGE_X_BENCHSTAT_VERSION_LATEST_MIN_GO }}
           runner-os: ${{ matrix.os }}
           go-version: ${{ matrix.go-version }}
 
@@ -235,10 +307,19 @@ jobs:
       - name: 🧪 Run tests
         id: run-tests
         continue-on-error: true
+        env:
+          # Route caller-provided matrix values through env: so they can never break out
+          # of the shell via ${{ }} interpolation (shell-safety invariant).
+          MATRIX_NAME: ${{ matrix.name }}
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_GO_VERSION: ${{ matrix.go-version }}
+          # Caller-provided flags routed through env: too (shell-safety invariant).
+          RACE_DETECTION_ENABLED: ${{ inputs.race-detection-enabled || 'false' }}
+          CODE_COVERAGE_ENABLED: ${{ inputs.code-coverage-enabled || 'false' }}
         run: |
           # Determine test type based on inputs
-          RACE="${{ inputs.race-detection-enabled || 'false' }}"
-          COVER="${{ inputs.code-coverage-enabled || 'false' }}"
+          RACE="${RACE_DETECTION_ENABLED:-false}"
+          COVER="${CODE_COVERAGE_ENABLED:-false}"
 
           echo "🔍 Race Detection Enabled: $RACE"
           echo "🔍 Code Coverage Enabled: $COVER"
@@ -292,7 +373,11 @@ jobs:
 
           # Emit GitHub annotation for test failures (surfaces at top of Actions UI)
           if [[ "$TEST_EXIT_CODE" != "0" ]]; then
-            echo "::error title=Test Suite Failed (${{ matrix.name }})::Tests failed on ${{ matrix.os }} with Go ${{ matrix.go-version }} - see job summary for details"
+            # Percent-encode untrusted matrix values before embedding in the workflow
+            # command so they can't inject their own ::commands (workflow-command
+            # injection). % must be encoded first to avoid double-decode.
+            esc() { local s=$1; s=${s//'%'/%25}; s=${s//$'\r'/%0D}; s=${s//$'\n'/%0A}; printf '%s' "$s"; }
+            echo "::error title=Test Suite Failed ($(esc "$MATRIX_NAME"))::Tests failed on $(esc "$MATRIX_OS") with Go $(esc "$MATRIX_GO_VERSION") - see job summary for details"
           fi
 
           # Calculate duration
@@ -386,15 +471,23 @@ jobs:
       # --------------------------------------------------------------------
       - name: 📊 Report Redis Cache Performance
         if: inputs.redis-enabled == 'true'
+        env:
+          # Route caller-provided inputs and step outputs through env: (shell-safety invariant).
+          REDIS_ENABLED: ${{ inputs.redis-enabled }}
+          REDIS_VERSION: ${{ inputs.redis-version }}
+          REDIS_CACHE_HIT: ${{ steps.setup-redis.outputs.cache-hit }}
+          REDIS_IMAGE_SIZE: ${{ steps.setup-redis.outputs.image-size }}
+          REDIS_CACHE_OP_TIME: ${{ steps.setup-redis.outputs.cache-operation-time }}
+          REDIS_CONNECTION_TIME: ${{ steps.setup-redis.outputs.connection-time }}
         run: |
           echo "📊 Redis Cache Performance Report"
           echo "================================="
-          echo "• Redis Enabled: ${{ inputs.redis-enabled }}"
-          echo "• Redis Version: ${{ inputs.redis-version }}"
-          echo "• Cache Hit: ${{ steps.setup-redis.outputs.cache-hit }}"
-          echo "• Image Size: ${{ steps.setup-redis.outputs.image-size }}MB"
-          echo "• Cache Operation Time: ${{ steps.setup-redis.outputs.cache-operation-time }}s"
-          echo "• Connection Time: ${{ steps.setup-redis.outputs.connection-time }}s"
+          echo "• Redis Enabled: ${REDIS_ENABLED}"
+          echo "• Redis Version: ${REDIS_VERSION}"
+          echo "• Cache Hit: ${REDIS_CACHE_HIT}"
+          echo "• Image Size: ${REDIS_IMAGE_SIZE}MB"
+          echo "• Cache Operation Time: ${REDIS_CACHE_OP_TIME}s"
+          echo "• Connection Time: ${REDIS_CONNECTION_TIME}s"
 
       # --------------------------------------------------------------------
       # Upload performance cache statistics for completion report
@@ -471,12 +564,31 @@ jobs:
       # no per-test FAIL event, so JSONL-based checks miss it while the process
       # exit code does not. Without this gate a real failure is masked and only
       # resurfaces downstream as the misleading "coverage file not found".
+      # Gate on run-tests actually having executed. If an earlier step (Go/MAGE-X
+      # setup, checkout, …) failed, run-tests is skipped and never records
+      # test-exit-code; without this gate the empty output reads as "!= 0" and this
+      # step masks the real setup failure behind a misleading "exited with '<unset>'".
+      # `outcome != 'skipped'` (not "output is empty") is deliberate: if run-tests
+      # *ran* but died before writing its output, we still enforce and fail closed
+      # rather than let a green slip through — run-tests is continue-on-error, so
+      # this step is the only thing that can fail the job on a bad test process.
       - name: 🚦 Enforce test exit code
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.run-tests.outcome != 'skipped' }}
+        env:
+          # Route matrix values (caller-provided) and the recorded exit code through env:
+          # so nothing can break out of the shell via ${{ }} (shell-safety invariant).
+          MATRIX_NAME: ${{ matrix.name }}
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_GO_VERSION: ${{ matrix.go-version }}
+          TEST_EXIT_CODE: ${{ steps.run-tests.outputs.test-exit-code }}
         run: |
-          CODE="${{ steps.run-tests.outputs.test-exit-code }}"
+          CODE="$TEST_EXIT_CODE"
           if [[ "$CODE" != "0" ]]; then
-            echo "::error title=Test Suite Failed (${{ matrix.name }})::go test exited with code '${CODE:-<unset>}' on ${{ matrix.os }} / Go ${{ matrix.go-version }} — see the '🧪 Run tests' step and job summary"
+            # Percent-encode untrusted matrix values before embedding in the workflow
+            # command so they can't inject their own ::commands (workflow-command
+            # injection). CODE is our own numeric exit code, so it needs no encoding.
+            esc() { local s=$1; s=${s//'%'/%25}; s=${s//$'\r'/%0D}; s=${s//$'\n'/%0A}; printf '%s' "$s"; }
+            echo "::error title=Test Suite Failed ($(esc "$MATRIX_NAME"))::go test exited with code '${CODE:-<unset>}' on $(esc "$MATRIX_OS") / Go $(esc "$MATRIX_GO_VERSION") — see the '🧪 Run tests' step and job summary"
             echo "❌ Failing job: test process exited '${CODE:-<unset>}' (expected 0)."
             exit 1
           fi


### PR DESCRIPTION
## What Changed

* Enhanced `.github/actions/setup-benchstat/action.yml` to support dual-version benchstat builds: added `benchstat-version-latest` and `benchstat-latest-min-go` inputs to enable version selection based on the runner's Go version
* Updated version check logic to parse and validate Go versions using regex anchoring, reject malformed inputs (e.g., "1.25junk", "127"), and select the appropriate benchstat build: Go < 1.25 skips installation, Go >= latest-min-go uses the latest build, Go 1.25.x uses the Go 1.25-compatible build
* Added `resolved-version` output to expose which benchstat version was selected for the runner's Go version
* Modified `.github/actions/validate-test-results/action.yml` to extract test result helper functions into a separate shell script for reusability
* Created `.github/scripts/test-result-helpers.sh` with functions for parsing test results, calculating pass/fail rates, and generating status messages
* Enhanced `.github/workflows/fortress-test-matrix.yml` to pass the new benchstat version inputs, use the extracted test result helper script, and add permissions configuration (`contents: read`)

## Why It Was Necessary

* The golang.org/x/perf project raises its `go.mod` directive over time, making newer benchstat builds incompatible with older Go toolchains, requiring version-aware selection to maintain compatibility across different runner Go versions
* Extracting test result parsing logic into a reusable shell script reduces duplication across GitHub Actions and improves maintainability
* Version updates for mage-x, pre-commit, and go-coverage bring bug fixes, improvements, and support for newer Go versions

## Testing Performed

* The setup-benchstat action now validates Go version inputs with anchored regex matching to reject malformed versions that were previously silently accepted
* Version selection logic tested across three scenarios: Go < 1.25 (skip), Go 1.25.x (use base version), and Go >= latest-min-go (use latest version)
* Test result helper script extracted and validated to ensure existing test result parsing and status reporting functionality remains intact

## Impact / Risk

* **Low risk** - Changes are additive with backward compatibility: `benchstat-version-latest` defaults to `benchstat-version` when unset, preserving existing behavior for callers that don't provide the new inputs
* **Improved robustness** - Version parsing now catches malformed inputs (e.g., "1.25junk") that would previously be silently coerced, preventing unexpected build selection
* **Maintenance benefit** - Centralized test result helpers and dual-version support reduce future update friction as benchstat and Go versions evolve across multiple projects that sync these workflow files

<!-- go-broadcast-metadata
group:
  id: bsv-blockchain-forks
  name: bsv-blockchain-forks
diff_info:
  staged_repo_available: true
  changed_files_count: 7
  files_with_original_content: 6
  files_without_original_content: 1
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: d45d090f77c820ce99175b79fc3d49dbf51e1277
  target_repo: bsv-blockchain/go-paymail
  sync_commit: 428c7709df0dfce41395fd2b9dae28b2f7ed3a1f
  sync_time: 2026-08-23T12:17:06-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 351
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 2
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1147
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 476
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 3
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 510
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 2
    files_excluded: 0
    processing_time_ms: 355
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1122
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1611
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 394
performance:
  total_files: 103
-->
